### PR TITLE
Fix ImportError: Replace pkg_resources with importlib.metadata

### DIFF
--- a/doc2dict/doc2dict/html/convert_instructions_to_dict.py
+++ b/doc2dict/doc2dict/html/convert_instructions_to_dict.py
@@ -1,7 +1,7 @@
 import re
-import pkg_resources
+from importlib.metadata import version
 
-version = pkg_resources.get_distribution("doc2dict").version
+__version__ = version("doc2dict")
 
 LIKELY_HEADER_ATTRIBUTES = ['bold', 'italic', 'underline', 'text-center', 'all_caps', 'fake_table','proper_case']
 
@@ -345,7 +345,7 @@ def convert_instructions_to_dict(instructions_list, mapping_dict=None):
         'metadata': {
             'parser': 'doc2dict',
             'github': 'https://github.com/john-friedman/doc2dict',
-            'version': version
+            "version": __version__,
         },
         'document': document['contents']
     }


### PR DESCRIPTION
## Fix ImportError: Replace pkg_resources with importlib.metadata

**Problem**: When trying to use `dict_10k_html` function from this package, it raises an error on import in environments where `setuptools` (which provides `pkg_resources`) is not installed, causing `ModuleNotFoundError: No module named 'pkg_resources'`.

**Solution**: Replace legacy `pkg_resources.get_distribution()` with modern `importlib.metadata.version()` from the standard library (it is included in python since 3.8+ and so no external dependency is needed).

**Changes**:
```python
# Before
import pkg_resources
version = pkg_resources.get_distribution("doc2dict").version

# After  
from importlib.metadata import version
__version__ = version("doc2dict")
```

**Benefits**:
- No external dependencies required (`importlib.metadata` is stdlib since Python 3.8)
- Faster imports (no heavy `setuptools` dependency)
- Same functionality - both return the installed package version string
- Future-proof modern approach recommended by Python packaging guidelines

This change maintains identical behavior while eliminating the runtime dependency on `setuptools`.