### PR TITLE
Fix missed standardized_title due to whitespace

### DIFF
--- a/doc2dict/doc2dict/html/convert_instructions_to_dict.py
+++ b/doc2dict/doc2dict/html/convert_instructions_to_dict.py
@@ -237,7 +237,7 @@ def determine_levels(instructions_list, mapping_dict=None):
             level = create_level(-2, 'textsmall')
         elif 'text' in header:
             if mapping_dict is not None:
-                text = header['text'].lower()
+                text = header['text'].lower().strip()
                 regex_tuples = [(item[0][1], item[0][0], item[1]) for item in mapping_dict.items()]
                 
                 for regex, header_class, hierarchy_level in regex_tuples:


### PR DESCRIPTION
When the title had surrounding whitespace, it wasn't matching the 10k mapping dict regex for titles.

E.g. `" Item 1A.  "` didn't match the regex and wouldn't be give standardized_title of "item1a"

For example, in the case of [this](https://www.sec.gov/ix?doc=/Archives/edgar/data/0000096021/000009602125000099/syy-20250628.htm#i21ff2967d6114a4e9f3f52aac8af4a94_16) 10K, the Risk Factors section is not given a standardized_title but this change will fix it.